### PR TITLE
Updating RandomWord API URL

### DIFF
--- a/random_micro.py
+++ b/random_micro.py
@@ -1,7 +1,7 @@
 import requests
 
 
-RANDOM_WORD_API_URL = 'http://randomword.setgetgo.com/get.php'
+RANDOM_WORD_API_URL = 'http://setgetgo.com/randomword/get.php'
 RANDOM_WORD_API_PARAMS = {'len': 5}
 
 


### PR DESCRIPTION
Updating RandomWord API URL:
from: http://randomword.setgetgo.com/get.php
to: http://setgetgo.com/randomword/get.php
The old url no longer works.
